### PR TITLE
Make colouring of operators consistent across languages.

### DIFF
--- a/Solarized (dark).tmTheme
+++ b/Solarized (dark).tmTheme
@@ -109,6 +109,19 @@
 			</dict>
 		</dict>
 		<dict>
+		    <key>name</key>
+		    <string>Arithmetical, Assignment, Comparision Operators</string>
+		    <key>scope</key>
+		    <string>keyword.operator.comparison, keyword.operator.assignment, keyword.operator.arithmetic</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>fontStyle</key>
+		        <string></string>
+		        <key>foreground</key>
+		        <string>#839496</string>
+		    </dict>
+		</dict>
+		<dict>
 			<key>name</key>
 			<string>Storage</string>
 			<key>scope</key>

--- a/Solarized (light).tmTheme
+++ b/Solarized (light).tmTheme
@@ -109,6 +109,19 @@
 			</dict>
 		</dict>
 		<dict>
+		    <key>name</key>
+		    <string>Arithmetical, Assignment, Comparision Operators</string>
+		    <key>scope</key>
+		    <string>keyword.operator.comparison, keyword.operator.assignment, keyword.operator.arithmetic</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>fontStyle</key>
+		        <string></string>
+		        <key>foreground</key>
+		        <string>#657B83</string>
+		    </dict>
+		</dict>
+		<dict>
 			<key>name</key>
 			<string>Storage</string>
 			<key>scope</key>


### PR DESCRIPTION
This change will affect themes in such way that arithmetical, comparision
and assignment operators are not colored in any language. Previously they
were not colored in e.g c++ but were colored in Python. This is also
consistent with orginal Solarized theme.