### PR TITLE
Remove StringNumber from theme definitions

### DIFF
--- a/Solarized (dark).tmTheme
+++ b/Solarized (dark).tmTheme
@@ -69,17 +69,6 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>StringNumber</string>
-			<key>scope</key>
-			<string>string</string>
-			<key>settings</key>
-			<dict>
-				<key>foreground</key>
-				<string>#6c71c4</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>name</key>
 			<string>Regexp</string>
 			<key>scope</key>
 			<string>string.regexp</string>

--- a/Solarized (light).tmTheme
+++ b/Solarized (light).tmTheme
@@ -69,17 +69,6 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>StringNumber</string>
-			<key>scope</key>
-			<string>string</string>
-			<key>settings</key>
-			<dict>
-				<key>foreground</key>
-				<string>#6c71c4</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>name</key>
 			<string>Regexp</string>
 			<key>scope</key>
 			<string>string.regexp</string>


### PR DESCRIPTION
StringNumber seems to do nothing but mask String, resulting in unquoted strings
having a different color than quoted strings. This resolves the issue by
removing StringNumber.